### PR TITLE
remove const qualification of top-level function

### DIFF
--- a/src/doc.h
+++ b/src/doc.h
@@ -22,7 +22,7 @@ public:
   
   const vector<int>& get_ws() const {return ws;}
   
-  const int get_w(int i) const {
+  int get_w(int i) const {
 	assert(i < ((int)ws.size()));
 	return ws[i];
   }

--- a/src/pmat.h
+++ b/src/pmat.h
@@ -126,9 +126,9 @@ public:
 	}
   }
   
-  const int rows() const {return array.size();}
-  const int size() const {return rows();}
-  const int cols() const {return rows()?array[0].size():0;}
+  int rows() const {return array.size();}
+  int size() const {return rows();}
+  int cols() const {return rows()?array[0].size():0;}
 
   Pvec<T> &operator[] (int m){
 	if (m >= (int)array.size())


### PR DESCRIPTION
Flagged by the `readability-const-return-type` tool:

https://clang.llvm.org/extra/clang-tidy/checks/readability/const-return-type.html